### PR TITLE
Add script to remove logs without sessionID

### DIFF
--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,0 +1,2 @@
+This directory is for dumping miscellaneous scripts such as cleanup scripts for the Firebase DB, periodically cleaning
+up shuttles via a cron job, etc.

--- a/src/scripts/remove-logs-without-sessionid.js
+++ b/src/scripts/remove-logs-without-sessionid.js
@@ -1,0 +1,30 @@
+const admin = require('firebase-admin');
+
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+  databaseURL: 'https://bloombus-163620.firebaseio.com'
+});
+
+const db = admin.database();
+const logsRef = db.ref('logs');
+
+logsRef.once('value')
+  .then(async snapshot => {
+    if (snapshot.empty) {
+      console.log('No matching documents.');
+      return;
+    }  
+
+    let numRemoved = 0;
+    snapshot.forEach(logSnapshot => {
+      const logData = logSnapshot.val();
+      if (!logData.hasOwnProperty('sessionID')) {
+        logSnapshot.ref.remove();
+        numRemoved++;
+      }
+    });
+    console.log(`Removed ${numRemoved} documents.`);
+  })
+  .catch(err => {
+    console.log('Error getting documents', err);
+  });


### PR DESCRIPTION
Supports Michael O'Donnell's work to add a `sessionID` property to the historical logs.

Purges log entries in the Firebase DB that do not have the new property.